### PR TITLE
[nuget] Fix inclusion of native libraries when referencing Mono.Unix

### DIFF
--- a/src/Mono.Unix/Mono.Unix.dll.config
+++ b/src/Mono.Unix/Mono.Unix.dll.config
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <dllmap dll="Mono.Unix" os="linux" cpu="x86-64" wordsize="64" target="runtimes/linux-x64/libMono.Unix.so" />
+  <dllmap dll="Mono.Unix" os="osx" cpu="x86-64" wordsize="64" target="runtimes/osx-x64/libMono.Unix.so" />
+  <dllmap dll="Mono.Unix" os="osx" cpu="armv8" wordsize="64" target="runtimes/osx-arm64/libMono.Unix.so" />
+</configuration>

--- a/src/Mono.Unix/Mono.Unix.proj
+++ b/src/Mono.Unix/Mono.Unix.proj
@@ -205,4 +205,26 @@
       </Content>
     </ItemGroup>
   </Target>
+
+  <PropertyGroup>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_IncludeDllConfigInNuGetPackage</TargetsForTfmSpecificContentInPackage>
+  </PropertyGroup>
+  <Target Name="_IncludeDllConfigInNuGetPackage">
+    <GetNuGetShortFolderName
+        TargetFrameworkMoniker="$(TargetFrameworkMoniker)"
+        TargetPlatformMoniker="$(TargetPlatformMoniker)">
+      <Output TaskParameter="NuGetShortFolderName" PropertyName="_NuGetShortFolderName" />
+    </GetNuGetShortFolderName>
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(MSBuildThisFileDirectory)Mono.Unix.dll.config">
+        <PackagePath>lib/$(_NuGetShortFolderName)</PackagePath>
+      </TfmSpecificPackageFile>
+    </ItemGroup>
+  </Target>
+
+  <ItemGroup>
+    <Content Include="$(MSBuildThisFileDirectory)Mono.Unix.targets">
+      <PackagePath>build</PackagePath>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/src/Mono.Unix/Mono.Unix.targets
+++ b/src/Mono.Unix/Mono.Unix.targets
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Condition=" '$(TargetFrameworkIdentifier)' != '.NETCoreApp' ">
+    <_MonoUnixRuntimeId Include="android-arm">
+      <DSOExtension>so</DSOExtension>
+      <FolderName>%(Identity)</FolderName>
+    </_MonoUnixRuntimeId>
+    <_MonoUnixRuntimeId Include="android-arm64">
+      <DSOExtension>so</DSOExtension>
+      <FolderName>%(Identity)</FolderName>
+    </_MonoUnixRuntimeId>
+    <_MonoUnixRuntimeId Include="android-x64">
+      <DSOExtension>so</DSOExtension>
+      <FolderName>%(Identity)</FolderName>
+    </_MonoUnixRuntimeId>
+    <_MonoUnixRuntimeId Include="android-x86">
+      <DSOExtension>so</DSOExtension>
+      <FolderName>%(Identity)</FolderName>
+    </_MonoUnixRuntimeId>
+    <_MonoUnixRuntimeId Include="linux-x64">
+      <DSOExtension>so</DSOExtension>
+      <FolderName>%(Identity)</FolderName>
+    </_MonoUnixRuntimeId>
+    <_MonoUnixRuntimeId Include="osx-arm64">
+      <DSOExtension>dylib</DSOExtension>
+      <FolderName>%(Identity)</FolderName>
+    </_MonoUnixRuntimeId>
+    <_MonoUnixRuntimeId Include="osx-x64">
+      <DSOExtension>dylib</DSOExtension>
+      <FolderName>%(Identity)</FolderName>
+    </_MonoUnixRuntimeId>
+
+    <_MonoUnixNativeLibs Include="@(_MonoUnixRuntimeId->'$(MSBuildThisFileDirectory)../runtimes/%(Identity)/native/libMono.Unix.%(DSOExtension)')">
+      <Link>runtimes/%(FolderName)/%(FileName)%(Extension)</Link>
+    </_MonoUnixNativeLibs>
+
+    <None Include="@(_MonoUnixNativeLibs)">
+      <Link>%(Link)</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+
+    <None Include="$(MSBuildThisFileDirectory)../lib/net45/Mono.Unix.dll.config">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Add a `Mono.Unix.targets` file which copies all the native libraries
into the referencing project's output directory, putting each native
library in respective `runtimes/RID` directory where `RID` is the
runtime ID of the native library.

Add a `dllmap` configuration for Mono so that it can find native
libraries in the above directories.