### PR TITLE
Add Linux arm64 and arm32 cross builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -195,7 +195,9 @@ function __build_host()
 		build_common ${HOST_BUILD_NAME}-x64 -DTARGET_PLATFORM=host-${OS_LOWER}-x64
 		build_common ${HOST_BUILD_NAME}-arm64 -DTARGET_PLATFORM=host-${OS_LOWER}-arm64
 	else
-		build_common ${HOST_BUILD_NAME} -DTARGET_PLATFORM=host-${OS_LOWER}
+		build_common ${HOST_BUILD_NAME}-x64 -DTARGET_PLATFORM=host-${OS_LOWER}-x64
+		build_common ${HOST_BUILD_NAME}-arm64 -DTARGET_PLATFORM=host-${OS_LOWER}-arm64
+		build_common ${HOST_BUILD_NAME}-arm32 -DTARGET_PLATFORM=host-${OS_LOWER}-arm32
 	fi
 
 	HOST_BUILT="yes"
@@ -318,7 +320,15 @@ function __build_test()
 		case $(arch) in
 			i386) arch="-x64" ;;
 			arm64) arch="-arm64" ;;
-			*) die "Unknown host architecture: $(arch)" ;;
+			*) die "Unknown macOS host architecture: $(arch)" ;;
+		esac
+	elif [ "${OS}" == "Linux" ]; then
+		case $(arch) in
+			i686) die 32-bit x86 Linux build not supported ;;
+			x86_64) arch="-x64" ;;
+			armv7l) arch="-arm32" ;;
+			arm64) arch="-arm64" ;;
+			*) die "Unknown Linux host architecture: $(arch)" ;;
 		esac
 	fi
 

--- a/ci/azure-pipelines.yaml
+++ b/ci/azure-pipelines.yaml
@@ -31,9 +31,21 @@ stages:
 
     - template: templates/pack-artifact.yaml
       parameters:
-        buildDir: '$(LinuxHostBuildDir)'
-        archiveName: '$(LinuxHostArchiveName)'
-        displayName: 'Archive Linux host build'
+        buildDir: '$(LinuxHostX64BuildDir)'
+        archiveName: '$(LinuxHostX64ArchiveName)'
+        displayName: 'Archive Linux host X86-64 build'
+
+    - template: templates/pack-artifact.yaml
+      parameters:
+        buildDir: '$(LinuxHostArm64BuildDir)'
+        archiveName: '$(LinuxHostArm64ArchiveName)'
+        displayName: 'Archive Linux host ARM64 build'
+
+    - template: templates/pack-artifact.yaml
+      parameters:
+        buildDir: '$(LinuxHostArm32BuildDir)'
+        archiveName: '$(LinuxHostArm32ArchiveName)'
+        displayName: 'Archive Linux host ARM32 (Hard Float) build'
 
     - task: PublishBuildArtifacts@1
       displayName: Upload Artifacts
@@ -218,10 +230,10 @@ stages:
 
     - template: templates/extract-artifact.yaml
       parameters:
-        displayName: Extract Linux host build
+        displayName: Extract Linux host X86-64 build
         artifactName: 'Host'
-        archiveName: '$(LinuxHostArchiveName)'
-        destinationFolder: '$(LinuxHostBuildDir)'
+        archiveName: '$(LinuxHostX64ArchiveName)'
+        destinationFolder: '$(LinuxHostX64BuildDir)'
 
     - template: templates/extract-artifact.yaml
       parameters:
@@ -360,10 +372,24 @@ stages:
 
         - template: /ci/templates/extract-artifact.yaml
           parameters:
-            displayName: Extract Linux host build
+            displayName: Extract Linux host X86-64 build
             artifactName: 'Host'
-            archiveName: '$(LinuxHostArchiveName)'
-            destinationFolder: '$(LinuxHostBuildDir)'
+            archiveName: '$(LinuxHostX64ArchiveName)'
+            destinationFolder: '$(LinuxHostX64BuildDir)'
+
+        - template: /ci/templates/extract-artifact.yaml
+          parameters:
+            displayName: Extract Linux host ARM64 build
+            artifactName: 'Host'
+            archiveName: '$(LinuxHostArm64ArchiveName)'
+            destinationFolder: '$(LinuxHostArm64BuildDir)'
+
+        - template: /ci/templates/extract-artifact.yaml
+          parameters:
+            displayName: Extract Linux host ARM32 build
+            artifactName: 'Host'
+            archiveName: '$(LinuxHostArm32ArchiveName)'
+            destinationFolder: '$(LinuxHostArm32BuildDir)'
 
         - template: /ci/templates/extract-artifact.yaml
           parameters:

--- a/ci/common-variables.yml
+++ b/ci/common-variables.yml
@@ -42,10 +42,23 @@ variables:
     value: $(ArchiveNameBase)-host
 
   # Linux
-  - name: LinuxHostBuildDir
-    value: $(BuildDirName)/host-linux-release/lib
-  - name: LinuxHostArchiveName
-    value: $(HostArchiveNameBase)-linux-x64
+  - name: LinuxHostArchiveNameBase
+    value: $(HostArchiveNameBase)-linux
+  - name: LinuxHostBuildDirBase
+    value: $(BuildDirName)/host-linux
+  - name: LinuxHostX64BuildDir
+    value: $(LinuxHostBuildDirBase)-x64-release/lib
+  - name: LinuxHostX64ArchiveName
+    value: $(LinuxHostArchiveNameBase)-x64
+  - name: LinuxHostArm64BuildDir
+    value: $(LinuxHostBuildDirBase)-arm64-release/lib
+  - name: LinuxHostArm64ArchiveName
+    value: $(LinuxHostArchiveNameBase)-arm64
+  - name: LinuxHostArm32BuildDir
+    value: $(LinuxHostBuildDirBase)-arm32-release/lib
+  - name: LinuxHostArm32ArchiveName
+    value: $(LinuxHostArchiveNameBase)-arm32
+
   # Android
   - name: AndroidArchiveNameBase
     value: $(ArchiveNameBase)-android

--- a/ci/templates/linux-common.yaml
+++ b/ci/templates/linux-common.yaml
@@ -5,5 +5,5 @@ steps:
 
     - bash: |
         sudo apt -y update
-        sudo apt -f -u install ninja-build -y
+        sudo apt -f -u install ninja-build g++-arm-linux-gnueabihf g++-aarch64-linux-gnu -y
       displayName: 'Install ninja'

--- a/cmake/toolchain.linux.cmake
+++ b/cmake/toolchain.linux.cmake
@@ -1,0 +1,28 @@
+if(TARGET_PLATFORM MATCHES "^host-linux-.*")
+  set(IS_CROSS_BUILD True)
+  if(TARGET_PLATFORM STREQUAL host-linux-arm64)
+    set(CMAKE_SYSTEM_PROCESSOR aarch64)
+    set(TRIPLE "aarch64-linux-gnu" CACHE STRING "" FORCE)
+  elseif(TARGET_PLATFORM STREQUAL host-linux-arm32)
+    set(CMAKE_SYSTEM_PROCESSOR armv7l)
+    set(TRIPLE "arm-linux-gnueabihf" CACHE STRING "" FORCE)
+  else()
+    set(IS_CROSS_BUILD False)
+    set(TRIPLE "" CACHE STRING "" FORCE)
+    set(TOOLCHAIN_PREFIX "" CACHE STRING "" FORCE)
+  endif()
+
+  if(IS_CROSS_BUILD)
+    set(CMAKE_SYSTEM_NAME Linux)
+    set(CMAKE_CROSSCOMPILING True)
+
+    set(TOOLCHAIN_PREFIX "${TRIPLE}-" CACHE STRING "" FORCE)
+
+    set(CMAKE_C_COMPILER ${TRIPLE}-gcc)
+    set(CMAKE_CXX_COMPILER ${TRIPLE}-g++)
+
+    set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)
+    set(CMAKE_FIND_ROOT_PATH_MODE_LIBRARY ONLY)
+    set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
+  endif()
+endif()

--- a/src/Mono.Unix/Mono.Unix.proj
+++ b/src/Mono.Unix/Mono.Unix.proj
@@ -27,8 +27,28 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <_NativeLib Include="host-linux" Condition=" '$([MSBuild]::IsOSPlatform(Linux))' == 'true' or '$(PackageAllNativeLibs)' == 'true' ">
+    <_NativeLib Include="host-linux-x64" Condition=" '$([MSBuild]::IsOSPlatform(Linux))' == 'true' or '$(PackageAllNativeLibs)' == 'true' ">
       <PackagePath>runtimes/linux-x64/native</PackagePath>
+      <LibraryPrefix>$(_LinuxLibraryPrefix)</LibraryPrefix>
+      <SharedSuffix>$(_LinuxSharedNativeLibrarySuffix)</SharedSuffix>
+      <StaticSuffix>$(_LinuxStaticNativeLibrarySuffix)</StaticSuffix>
+      <DebugSuffix>$(_LinuxDebugNativeLibrarySuffix)</DebugSuffix>
+      <HasDebugLibrary>$(_LinuxHasDebugNativeLibrary)</HasDebugLibrary>
+      <HasSharedLibrary>true</HasSharedLibrary>
+    </_NativeLib>
+
+    <_NativeLib Include="host-linux-arm64" Condition=" '$([MSBuild]::IsOSPlatform(Linux))' == 'true' or '$(PackageAllNativeLibs)' == 'true' ">
+      <PackagePath>runtimes/linux-arm64/native</PackagePath>
+      <LibraryPrefix>$(_LinuxLibraryPrefix)</LibraryPrefix>
+      <SharedSuffix>$(_LinuxSharedNativeLibrarySuffix)</SharedSuffix>
+      <StaticSuffix>$(_LinuxStaticNativeLibrarySuffix)</StaticSuffix>
+      <DebugSuffix>$(_LinuxDebugNativeLibrarySuffix)</DebugSuffix>
+      <HasDebugLibrary>$(_LinuxHasDebugNativeLibrary)</HasDebugLibrary>
+      <HasSharedLibrary>true</HasSharedLibrary>
+    </_NativeLib>
+
+    <_NativeLib Include="host-linux-arm32" Condition=" '$([MSBuild]::IsOSPlatform(Linux))' == 'true' or '$(PackageAllNativeLibs)' == 'true' ">
+      <PackagePath>runtimes/linux-arm/native</PackagePath>
       <LibraryPrefix>$(_LinuxLibraryPrefix)</LibraryPrefix>
       <SharedSuffix>$(_LinuxSharedNativeLibrarySuffix)</SharedSuffix>
       <StaticSuffix>$(_LinuxStaticNativeLibrarySuffix)</StaticSuffix>

--- a/src/native/CMakeLists.txt
+++ b/src/native/CMakeLists.txt
@@ -22,6 +22,7 @@ endif()
 #
 include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/toolchain.android.cmake)
 include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/toolchain.apple.cmake)
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/toolchain.linux.cmake)
 
 project(
   Mono.Unix
@@ -74,7 +75,7 @@ set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 
-set(CMAKE_SKIP_INSTALL_RPATH TRUE)
+set(CMAKE_SKIP_INSTALL_RPATH True)
 set(CMAKE_SKIP_RPATH True)
 
 set(CMAKE_CXX_STANDARD 17)
@@ -133,6 +134,10 @@ else()
 
   if(ANDROID)
     set(IS_ANDROID True)
+  endif()
+
+  if(NOT ANDROID AND CMAKE_HOST_SYSTEM_NAME STREQUAL Linux)
+    set(IS_LINUX True)
   endif()
 
   # TODO: WASM must be defined in a toolchain file
@@ -675,8 +680,8 @@ endif()
 #
 if(IS_LINUX OR IS_ANDROID)
   if(IS_LINUX)
-    set(OBJCOPY "objcopy")
-    set(STRIP "strip")
+    set(OBJCOPY "${TOOLCHAIN_PREFIX}objcopy")
+    set(STRIP "${TOOLCHAIN_PREFIX}strip")
   else()
     set(OBJCOPY "${ANDROID_TOOLCHAIN_ROOT}/bin/llvm-objcopy${ANDROID_TOOLCHAIN_SUFFIX}")
     set(STRIP "${ANDROID_TOOLCHAIN_ROOT}/bin/llvm-strip${ANDROID_TOOLCHAIN_SUFFIX}")


### PR DESCRIPTION
Add support for cross-building ARM64 and ARM32 (hard float) binaries on
Linux.