### PR TITLE
[dotnet] Use `NativeLibrary` to load `libMono.Unix` DSO

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -2,6 +2,6 @@
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <VersionPrefix>7.0.0</VersionPrefix>
-    <PreReleaseVersionLabel>alpha3</PreReleaseVersionLabel>
+    <PreReleaseVersionLabel>alpha4</PreReleaseVersionLabel>
   </PropertyGroup>
 </Project>

--- a/src/Mono.Unix/Mono.Unix.Native/NativeLibraryInitializer.cs
+++ b/src/Mono.Unix/Mono.Unix.Native/NativeLibraryInitializer.cs
@@ -1,0 +1,104 @@
+#if NETCOREAPP3_0_OR_GREATER
+using System;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+
+namespace Mono.Unix.Native
+{
+	static class NativeLibraryInitializer
+	{
+		const string MonoUnixLibraryName = "Mono.Unix";
+
+		static readonly object initLock = new object();
+
+		static bool initialized;
+		static string monoUnixLibraryRuntimesPath = String.Empty;
+		static string monoUnixLibrarySiblingPath = String.Empty;
+
+		static IntPtr DllImportResolver(string libraryName, Assembly assembly, DllImportSearchPath? searchPath)
+		{
+			// Mostly for tests running in-repository
+			if (File.Exists (monoUnixLibrarySiblingPath)) {
+				return NativeLibrary.Load (monoUnixLibrarySiblingPath);
+			}
+
+			// We could check if the file exists, but let's instead `Load` throw an exception here
+			if (String.Compare (libraryName, MonoUnixLibraryName, StringComparison.OrdinalIgnoreCase) == 0) {
+				return NativeLibrary.Load (monoUnixLibraryRuntimesPath);
+			}
+
+			// Let the runtime find this library using its own algorithm
+			return IntPtr.Zero;
+		}
+
+		public static void Init ()
+		{
+			if (initialized) {
+				return;
+			}
+
+			lock (initLock) {
+				DoInit ();
+				initialized = true;
+			}
+		}
+
+		static void DoInit ()
+		{
+			// If anything goes wrong, fail quietly, let other code yell it doesn't work
+			var sb = new StringBuilder ();
+			string extension;
+
+			if (RuntimeInformation.IsOSPlatform (OSPlatform.OSX)) {
+				sb.Append ("osx-");
+				if (!AppendOSXArchitecture (sb)) {
+					return;
+				}
+				extension = "dylib";
+			} else if (RuntimeInformation.IsOSPlatform (OSPlatform.Linux)) {
+				sb.Append ("linux-");
+				if (!AppendLinuxArchitecture (sb)) {
+					return;
+				}
+				extension = "so";
+			} else {
+				return;
+			}
+
+			Assembly asm = typeof(NativeLibraryInitializer).Assembly;
+			string asmDir = Path.GetDirectoryName (asm.Location)!;
+			monoUnixLibraryRuntimesPath = Path.Combine (asmDir, "runtimes", sb.ToString (), $"lib{MonoUnixLibraryName}.{extension}");
+			monoUnixLibrarySiblingPath = Path.Combine (asmDir, Path.GetFileName (monoUnixLibraryRuntimesPath));
+
+			NativeLibrary.SetDllImportResolver (asm, DllImportResolver);
+		}
+
+		static bool AppendLinuxArchitecture (StringBuilder sb)
+		{
+			if (RuntimeInformation.OSArchitecture == Architecture.X64) {
+					sb.Append ("x64");
+					return true;
+			}
+
+			return false;
+		}
+
+		static bool AppendOSXArchitecture (StringBuilder sb)
+		{
+			switch (RuntimeInformation.OSArchitecture) {
+				case Architecture.X64:
+					sb.Append ("x64");
+					return true;
+
+				case Architecture.Arm64:
+					sb.Append ("arm64");
+					return true;
+			}
+
+			return false;
+		}
+	}
+}
+#endif // NETCOREAPP3_0_OR_GREATER

--- a/src/Mono.Unix/Mono.Unix.Native/Stdlib.cs
+++ b/src/Mono.Unix/Mono.Unix.Native/Stdlib.cs
@@ -424,6 +424,9 @@ namespace Mono.Unix.Native {
 		static Stdlib ()
 		{
 			VersionCheck ();
+#if NETCOREAPP3_0_OR_GREATER
+			NativeLibraryInitializer.Init ();
+#endif // NETCOREAPP3_0_OR_GREATER
 		}
 
 		internal Stdlib () {}

--- a/src/Mono.Unix/Mono.Unix/Catalog.cs
+++ b/src/Mono.Unix/Mono.Unix/Catalog.cs
@@ -35,6 +35,8 @@
 using System;
 using System.Runtime.InteropServices;
 
+using Mono.Unix.Native;
+
 namespace Mono.Unix {
 
 	public class Catalog {
@@ -47,6 +49,13 @@ namespace Mono.Unix {
 			IntPtr codeset);
 		[DllImport("intl", CallingConvention=CallingConvention.Cdecl)]
 		static extern IntPtr textdomain (IntPtr domainname);
+
+#if NETCOREAPP3_0_OR_GREATER
+		static Catalog ()
+		{
+			NativeLibraryInitializer.Init ();
+		}
+#endif // NETCOREAPP3_0_OR_GREATER
 
 		public static void Init (String package, String localedir)
 		{

--- a/src/Mono.Unix/Mono.Unix/UnixSignal.cs
+++ b/src/Mono.Unix/Mono.Unix/UnixSignal.cs
@@ -42,6 +42,9 @@ namespace Mono.Unix {
 		static UnixSignal ()
 		{
 			Stdlib.VersionCheck ();
+#if NETCOREAPP3_0_OR_GREATER
+			NativeLibraryInitializer.Init ();
+#endif // NETCOREAPP3_0_OR_GREATER
 		}
 
 		public UnixSignal (Signum signum)


### PR DESCRIPTION
`dotnet` needs this in order to be able to locate the shared library in
the `runtimes` subdirectory of the directory where `Mono.Unix.dll`
lives.  The code is enabled only for `netcoreapp` builds.