### PR TITLE
Update Microsoft.NET.Test.Sdk to later version

### DIFF
--- a/ci/azure-pipelines.yaml
+++ b/ci/azure-pipelines.yaml
@@ -210,7 +210,7 @@ stages:
         pathToPublish: $(Build.ArtifactStagingDirectory)
 
 - stage: test
-  condition: ne('${{ variables._RunAsInternal }}', 'True')
+  condition: and(ne('${{ variables._RunAsInternal }}', 'True'), succeeded('build_artifacts'))
   dependsOn: build_artifacts
   jobs:
   - job: linux_test

--- a/tests/Mono.Unix.Tests/Mono.Unix.Tests.csproj
+++ b/tests/Mono.Unix.Tests/Mono.Unix.Tests.csproj
@@ -17,6 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220726-02" />
+    <PackageReference Update="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220726-02" />
   </ItemGroup>
 </Project>

--- a/tests/Mono.Unix.Tests/Mono.Unix.Tests.csproj
+++ b/tests/Mono.Unix.Tests/Mono.Unix.Tests.csproj
@@ -16,4 +16,7 @@
     <Compile Include="./Mono.Unix*/*.cs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0-preview-20220726-02" />
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
It doesn't reference the vulnerable Newtonsoft.Json that gets flagged by Component Governance.

Also fix the `test` stage dependency so it only runs if `build_artifacts` succeeds.