### PR TITLE
Enable CodeQL with TSA

### DIFF
--- a/.config/tsaoptions.json
+++ b/.config/tsaoptions.json
@@ -1,0 +1,10 @@
+{
+    "instanceUrl": "https://devdiv.visualstudio.com/",
+    "template": "TFSDEVDIV",
+    "projectName": "DEVDIV",
+    "areaPath": "DevDiv\\mono",
+    "iterationPath": "DevDiv",
+    "notificationAliases": [ "runtimerepo-infra@microsoft.com" ],
+    "repositoryName": "mono.posix",
+    "codebaseName": "mono.posix"
+}

--- a/ci/common-variables.yml
+++ b/ci/common-variables.yml
@@ -25,6 +25,10 @@ variables:
         /p:TeamName=$(_TeamName)
         /p:DotNetPublishUsingPipelines=true
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
+    - name: Codeql.Enabled
+      value: True
+    - name: Codeql.TSAEnabled
+      value: True
 
   - name: BuildDirName
     value: artifacts


### PR DESCRIPTION
CodeQL is a static analysis tool that is able to scan source code to help detect security vulnerabilities. In mono/mono.posix, there already exists auto-injection of CodeQL's init and finalize tasks within the official default pipeline.

We enable CodeQL directly on the main pipeline as there are relatively few jobs, and because commits are relatively infrequent, there is no need for a separate pipeline to specify a cadence (periods between commits and therefore pipeline builds can be over a weeklong, so if there is no change, there is no need for a new codeql scan)

This PR does the following:
Enables CodeQL
Enable TSA with CodeQL