### PR TITLE
Avoid cleaning on checkout

### DIFF
--- a/ci/azure-pipelines-public.yaml
+++ b/ci/azure-pipelines-public.yaml
@@ -339,7 +339,6 @@ stages:
         steps:
 
         - checkout: self
-          clean: true
           submodules: recursive
 
         - task: DownloadBuildArtifacts@0

--- a/ci/azure-pipelines.yaml
+++ b/ci/azure-pipelines.yaml
@@ -263,7 +263,6 @@ extends:
             steps:
 
             - checkout: self
-              clean: true
               submodules: recursive
 
             - task: DownloadBuildArtifacts@0


### PR DESCRIPTION
Fixes issue with MicroBuild being deleted because it gets downloaded before checkout