### PR TITLE
Upgrade to V4 Arcade publishing

### DIFF
--- a/ci/azure-pipelines-public.yaml
+++ b/ci/azure-pipelines-public.yaml
@@ -320,7 +320,6 @@ stages:
       enableMicrobuild: true
       enablePublishBuildArtifacts: true
       enablePublishBuildAssets: true
-      enablePublishUsingPipelines: true
       variables:
         - _BuildConfig: Release
       jobs:

--- a/ci/azure-pipelines.yaml
+++ b/ci/azure-pipelines.yaml
@@ -235,12 +235,13 @@ extends:
           enableMicrobuild: true
           enablePublishBuildArtifacts: true
           enablePublishBuildAssets: true
-          enablePublishUsingPipelines: true
+          publishingVersion: 4
           variables:
             - _BuildConfig: Release
           jobs:
 
           - job: package
+            enablePublishing: true
             displayName: Create NuGet packages
             pool:
               name: $(DncEngInternalBuildPool)
@@ -442,6 +443,7 @@ extends:
     ############ POST BUILD ARCADE LOGIC ############
     - template: /eng/common/templates-official/post-build/post-build.yml@self
       parameters:
+        publishingInfraVersion: 4
         validateDependsOn: build_package
         enableSourceLinkValidation: false
         enableSigningValidation: false

--- a/ci/common-variables.yml
+++ b/ci/common-variables.yml
@@ -21,7 +21,6 @@ variables:
     - name: _InternalBuildArgs
       value: /p:DotNetSignType=$(_SignType) 
         /p:TeamName=$(_TeamName)
-        /p:DotNetPublishUsingPipelines=true
         /p:OfficialBuildId=$(BUILD.BUILDNUMBER)
     - name: Codeql.Enabled
       value: True

--- a/eng/Publishing.props
+++ b/eng/Publishing.props
@@ -1,5 +1,5 @@
 <Project>
   <PropertyGroup>
-    <PublishingVersion>3</PublishingVersion>
+    <PublishingVersion>4</PublishingVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Related to dotnet/arcade#16697.

This updates the repo from Arcade V3 publishing to V4 by:
- setting `PublishingVersion` to 4
- switching pipeline jobs to V4 `publishingVersion`/`enablePublishing`
- removing legacy V3 publish toggles (`enablePublishUsingPipelines`, `/p:DotNetPublishUsingPipelines=true`)
- setting `publishingInfraVersion: 4` on the post-build template

Blueprint: dotnet/binaryen#349.