### PR TITLE
Enable the Component Governance pull request policy

### DIFF
--- a/.azuredevops/policies/open_source_security_pr_policy.yml
+++ b/.azuredevops/policies/open_source_security_pr_policy.yml
@@ -1,0 +1,11 @@
+name: open_source_security_pr_policy
+description: 'Pull request policy to block introduction of new vulnerable packages.'
+resource: repository
+configuration:
+  componentGovernance:
+    securityPRSettings:
+      enabled: true
+      isBlocking: true
+      branches:
+      - ~default
+      minSeverity: 'High'


### PR DESCRIPTION
## Description

Add `.azuredevops/policies/open_source_security_pr_policy.yml` so that pull requests introducing packages with known high severity vulnerabilities are blocked against the default branch.

The Component Governance task reads this file at build time when no policy is registered in GitOps. The build for this pull request confirms it.

```
Component Governance Policy file found at path: D:\a\_work\1\s\.azuredevops\policies\open_source_security_pr_policy.yml
Component Governance Policy file read successfully...
```

Before this change the same task logged `Policy file does not exist at path`.
